### PR TITLE
AENT-8360: use the `latest` revision for project downloads

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1056,6 +1056,8 @@ class AEUserSession(AESessionBase):
     def project_download(self, ident, filename=None, format=None):
         rrec = self._revision(ident, keep_latest=True)
         prec, rev = rrec["_project"], rrec["id"]
+        if rrec["name"] == "latest":
+            rev = "latest"
         need_filename = not bool(filename)
         if need_filename:
             revdash = f'-{rrec["name"]}' if rrec["name"] != "latest" else ""


### PR DESCRIPTION
[Currently includes #192]

When the current `project_download` code sees a `latest` tag, it still downloads the latest _tagged_ revision. That's because the endpoint it hits still uses the latest revision ID. Instead we should pass `latest` up to workbench and let it handle that. Once related tickets are closed, this will download the latest commit, not just the latest tagged commit, which is what we would prefer.