### PR TITLE
Ensure the deployment name is preserved on restart

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1515,6 +1515,7 @@ class AEUserSession(AESessionBase):
         # Complete the restart
         return self.deployment_start(
             "{}:{}".format(drec["project_id"], drec["revision"]),
+            name=drec["name"],
             endpoint=endpoint,
             command=drec["command"],
             resource_profile=drec["resource_profile"],


### PR DESCRIPTION
Running `ae5 deployment restart {id}` currently doesn't preserve the existing deployment name, which I assume is a bug. This PR simply passes it to the `deployment_start` method internally used by this command.