### PR TITLE
[AENT-7570]/client side fixes

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1551,7 +1551,19 @@ class AEUserSession(AESessionBase):
 
     def deployment_patch(self, ident, format=None, **kwargs):
         drec = self._ident_record("deployment", ident)
-        data = {k: v for k, v in kwargs.items() if v is not None}
+        data = {k: v for k, v in kwargs.items() if v is not None and v != drec[k]}
+        if '_revision' in ident:
+            # add to data if current deployed revision is not _revision
+            # validate the revision exists before patching
+            dep2proj = {
+                'id': ident['project_id'],
+                'url': ident['project_url'],
+                '_revision': ident['_revision'],
+                '_record_type': 'project',
+            }
+            rrec = self._revision(dep2proj)
+            if drec['revision'] != rrec['name']:
+                data['revision'] = rrec['name']
         if data:
             id = drec["id"]
             self._patch(f"deployments/{id}", json=data)

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1552,18 +1552,18 @@ class AEUserSession(AESessionBase):
     def deployment_patch(self, ident, format=None, **kwargs):
         drec = self._ident_record("deployment", ident)
         data = {k: v for k, v in kwargs.items() if v is not None and v != drec[k]}
-        if '_revision' in ident:
+        if "_revision" in ident:
             # add to data if current deployed revision is not _revision
             # validate the revision exists before patching
             dep2proj = {
-                'id': ident['project_id'],
-                'url': ident['project_url'],
-                '_revision': ident['_revision'],
-                '_record_type': 'project',
+                "id": ident["project_id"],
+                "url": ident["project_url"],
+                "_revision": ident["_revision"],
+                "_record_type": "project",
             }
             rrec = self._revision(dep2proj)
-            if drec['revision'] != rrec['name']:
-                data['revision'] = rrec['name']
+            if drec["revision"] != rrec["name"]:
+                data["revision"] = rrec["name"]
         if data:
             id = drec["id"]
             self._patch(f"deployments/{id}", json=data)

--- a/ae5_tools/cli/commands/deployment.py
+++ b/ae5_tools/cli/commands/deployment.py
@@ -82,14 +82,21 @@ def token(**kwargs):
 
 
 @deployment.command()
-@ident_filter("deployment", required=True)
+@ident_filter("deployment", handle_revision=True, required=True)
 @click.option("--public/--private", is_flag=True, default=None, help="Make the deployment public/private (default).")
+@click.option("--resource-profile", help="Update resource profile for this deployment.")
 @global_options
 def patch(**kwargs):
     """Change a deployment's public/private status.
 
     The DEPLOYMENT identifier need not be fully specified, and may even include
     wildcards. But it must match exactly one deployment.
+
+    An example to update/change the revision of the project-deployment:
+
+        ae5 deployment patch DEPLOYMENT_IDENTIFIER:<revision>
+
+    The 'revision' can be 'latest' or revision contained in 'ae5 project revision list'.
     """
     cluster_call("deployment_patch", **kwargs)
 

--- a/tests/unit/ae5_tools/test_api_deployment.py
+++ b/tests/unit/ae5_tools/test_api_deployment.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+import pytest
 
 from ae5_tools import AEUserSession
 
@@ -43,7 +44,96 @@ def test_deployment_restart_with_same_name():
     )
 
 
+@pytest.mark.skip(reason="work in progress")
 def test_deployment_start():
     user_session: AEUserSession = AEUserSession(**base_params)
 
     request_params: dict = {"ident": "mock-ident", "wait": False, "format": "json"}
+
+
+def mock_ident(record_type, ident):
+    if record_type == "deployment":
+        mock_ident = ident
+    elif record_type == "project":
+        mock_ident = {
+            "id": ident["id"],
+            "project_url": ident["url"] if ident["_record_type"] == "project" else None,
+            "_record_type": "project"
+        }
+        if "_revision" in ident:
+            mock_ident["_revision"] = ident["_revision"]
+        print(f"\n\n{ident=}\n{mock_ident=}")
+    return mock_ident
+
+
+test_data = [
+    ({"public": False}, "latest"),  # latest is 0.1.1 - patch is not called
+    ({"public": False}, "None"),    # latest is 0.1.1 - patch is not called
+    ({"public": False, "resource_profile": "default"}, "0.1.1"),  # patch is not called
+    ({"public": True}, "0.1.0"),    # patch is called once
+    ({"resource_profile": "large", "public": True}, "0.1.0"),  # patch is called once
+]
+
+
+@pytest.mark.parametrize("kwargs_attr, revision", test_data)
+def test_deployment_patch(kwargs_attr, revision):
+    user_session: AEUserSession = AEUserSession(**base_params)
+    # Assume latest is 0.1.1
+    latest = '0.1.1'
+    mock_ident: dict = {
+        "id": "mock-id",
+        "project_id": "mock-project-id",
+        "revision": latest,
+        "resource_profile": "default",
+        "public": False,
+        "project_url": "http://anaconda-enterprise-ap-storage/projects/mock-project",
+        "_record_type": "deployment",
+    }
+    # revision is input to CLI separated by colon, eg:
+    #   <deployment-id>:<revision>
+    # the login.py module parses this and creates the ident record. If <revision> is given in CLI
+    # the ident record passed in from click contains _revision value
+    # The user_session._ident_record() returns the same dict
+    if revision:
+        mock_ident['_revision'] = revision
+    request_params: dict = {"ident": mock_ident, "format": "json"}
+    mock_resp: dict = {
+        "status_text": "Started",
+        "resource_profile": kwargs_attr.get("resource_profile", mock_ident["resource_profile"]),
+    }
+    user_session._ident_record = MagicMock(return_value=mock_ident)
+    # user_session._ident_record = MagicMock(_ident=mock_ident)
+    user_session._patch = MagicMock(return_value=mock_resp,)
+    if rev := mock_ident.get("_revision", None):
+        if rev == "does-not-exist":
+            mock_get_records = MagicMock(
+                side_effect=[Exception(f"Error: No revisions found matching name={mock_ident["_revision"]}")]
+            )
+        else:
+            proj_ident = mock_ident.get("project", mock_ident)
+            # latest gets written to the actual latest tag
+            rev = latest if rev == 'latest' else rev
+            mock_get_records = MagicMock(
+                return_value={
+                    "name": rev,
+                    "id": rev,
+                    "project_id": proj_ident["id"],
+                })
+        user_session._get_records = mock_get_records
+
+    user_session.deployment_patch(**request_params, **kwargs_attr)
+
+    # deployment_patch invokes -> _patch API call only if there are changes
+    _patch_called = False
+    for k, v in kwargs_attr.items():
+        if mock_ident[k] != v:
+            _patch_called = True
+            break
+    # if revision = 'latest'; then revision is same as mock_ident; so _patch should not be called
+    if revision != 'latest' and revision != mock_ident['revision']:
+        _patch_called = True
+
+    if _patch_called:
+        user_session._patch.assert_called_once()
+    else:
+        user_session._patch.assert_not_called()

--- a/tests/unit/ae5_tools/test_api_deployment.py
+++ b/tests/unit/ae5_tools/test_api_deployment.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+
 import pytest
 
 from ae5_tools import AEUserSession
@@ -55,11 +56,7 @@ def mock_ident(record_type, ident):
     if record_type == "deployment":
         mock_ident = ident
     elif record_type == "project":
-        mock_ident = {
-            "id": ident["id"],
-            "project_url": ident["url"] if ident["_record_type"] == "project" else None,
-            "_record_type": "project"
-        }
+        mock_ident = {"id": ident["id"], "project_url": ident["url"] if ident["_record_type"] == "project" else None, "_record_type": "project"}
         if "_revision" in ident:
             mock_ident["_revision"] = ident["_revision"]
         print(f"\n\n{ident=}\n{mock_ident=}")
@@ -68,9 +65,9 @@ def mock_ident(record_type, ident):
 
 test_data = [
     ({"public": False}, "latest"),  # latest is 0.1.1 - patch is not called
-    ({"public": False}, "None"),    # latest is 0.1.1 - patch is not called
+    ({"public": False}, "None"),  # latest is 0.1.1 - patch is not called
     ({"public": False, "resource_profile": "default"}, "0.1.1"),  # patch is not called
-    ({"public": True}, "0.1.0"),    # patch is called once
+    ({"public": True}, "0.1.0"),  # patch is called once
     ({"resource_profile": "large", "public": True}, "0.1.0"),  # patch is called once
 ]
 
@@ -79,7 +76,7 @@ test_data = [
 def test_deployment_patch(kwargs_attr, revision):
     user_session: AEUserSession = AEUserSession(**base_params)
     # Assume latest is 0.1.1
-    latest = '0.1.1'
+    latest = "0.1.1"
     mock_ident: dict = {
         "id": "mock-id",
         "project_id": "mock-project-id",
@@ -95,7 +92,7 @@ def test_deployment_patch(kwargs_attr, revision):
     # the ident record passed in from click contains _revision value
     # The user_session._ident_record() returns the same dict
     if revision:
-        mock_ident['_revision'] = revision
+        mock_ident["_revision"] = revision
     request_params: dict = {"ident": mock_ident, "format": "json"}
     mock_resp: dict = {
         "status_text": "Started",
@@ -103,22 +100,23 @@ def test_deployment_patch(kwargs_attr, revision):
     }
     user_session._ident_record = MagicMock(return_value=mock_ident)
     # user_session._ident_record = MagicMock(_ident=mock_ident)
-    user_session._patch = MagicMock(return_value=mock_resp,)
+    user_session._patch = MagicMock(
+        return_value=mock_resp,
+    )
     if rev := mock_ident.get("_revision", None):
         if rev == "does-not-exist":
-            mock_get_records = MagicMock(
-                side_effect=[Exception(f"Error: No revisions found matching name={mock_ident["_revision"]}")]
-            )
+            mock_get_records = MagicMock(side_effect=[Exception("Error: No revisions found matching name=".format(mock_ident["_revision"]))])
         else:
             proj_ident = mock_ident.get("project", mock_ident)
             # latest gets written to the actual latest tag
-            rev = latest if rev == 'latest' else rev
+            rev = latest if rev == "latest" else rev
             mock_get_records = MagicMock(
                 return_value={
                     "name": rev,
                     "id": rev,
                     "project_id": proj_ident["id"],
-                })
+                }
+            )
         user_session._get_records = mock_get_records
 
     user_session.deployment_patch(**request_params, **kwargs_attr)
@@ -130,7 +128,7 @@ def test_deployment_patch(kwargs_attr, revision):
             _patch_called = True
             break
     # if revision = 'latest'; then revision is same as mock_ident; so _patch should not be called
-    if revision != 'latest' and revision != mock_ident['revision']:
+    if revision != "latest" and revision != mock_ident["revision"]:
         _patch_called = True
 
     if _patch_called:


### PR DESCRIPTION
Add option to patch resource-profile; and the deployed-version.

## Testing ##

1. Ensure this is being tested against latest deployment of anaconda-platform master so it has this fix (https://github.com/anaconda/anaconda-platform/pull/6970) in.

2. Follow the same testing instructions on the server side as listed in this [PR#6970](https://github.com/anaconda/anaconda-platform/pull/6970#issue-2508880149) to start a deployment with version 0.1.0; then create an update and tag it as 0.1.1

3. Now use this updated client side ae5 version to apply the patches:

- Get the deployment ID and update to latest version. For the example below the deployment-id is `a2-eca80be7b7a143f78299bd615cf66ab5` 
```
% ae5 deployment list
% ae5 deployment patch a2-eca80be7b7a143f78299bd615cf66ab5:latest
```
Watch the `anaconda-app` pod get updated to the latest 0.1.1 deployment. You can verify in the UI; verify in the response printed by the client; you can also verify in the AE server UI.

- Get the deployment ID and update to older version. Verify the same things listed above ☝️ 
```
% ae5 deployment patch a2-eca80be7b7a143f78299bd615cf66ab5:0.1.0
```

- Give it an invalid version number and verify the response
```
% ae5 deployment patch a2-eca80be7b7a143f78299bd615cf66ab5:0.2.0
Connecting to user account anaconda-enterprise@anaconda.example.com.
Error: No revisions found matching name=0.2.0
```

- Test the resource-profile option also causes the pod to get restarted
```
ae5 deployment patch a2-eca80be7b7a143f78299bd615cf66ab5 --resource-profile large
```