### PR TITLE
Fix handling of relative redirect URLs

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -202,7 +202,7 @@ def _response_hook(resp, *args, **kwargs):
     prefix = req.method.upper()
     if url == last_redirect:
         prefix = "-> " + prefix
-    print(prefix, re.sub("[?].*", "?...", url), code, file=sys.stderr)
+    print(prefix, url, code, file=sys.stderr)
     last_redirect = resp.headers["location"] if 300 <= code < 400 else None
 
 

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -202,8 +202,8 @@ def _response_hook(resp, *args, **kwargs):
     prefix = req.method.upper()
     if url == last_redirect:
         prefix = "-> " + prefix
-    print(prefix, re.sub('[?].*', '?...', url), code, file=sys.stderr)
-    last_redirect = resp.headers['location'] if 300 <= code < 400 else None
+    print(prefix, re.sub("[?].*", "?...", url), code, file=sys.stderr)
+    last_redirect = resp.headers["location"] if 300 <= code < 400 else None
 
 
 class EmptyRecordList(list):
@@ -352,7 +352,7 @@ class AESessionBase(object):
         session.mount(prefix="https://", adapter=adapter)
 
         if get_env_var(name="API_DEBUG"):
-            session.hooks['response'].append(_response_hook)
+            session.hooks["response"].append(_response_hook)
 
         return session
 


### PR DESCRIPTION
[NOTE: INCLUDES #198]

Link to the single commit for this fix:
https://github.com/anaconda/ae5-tools/pull/200/commits/b478eae1fd29c25d469ddf9fc7dca2b172bd8f8e

A session URL looks like this:
```
https://6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com/
```
But if you visit this URL with a live VSCode session, it is redirected to
```
https://6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com/?folder=/opt/continuum/project
```
The `Location` header that directs you there is relative:
```
Location: ./?folder=/opt/continuum/project
```
Our code is not handling that properly. To fix it, I opted to pull in `urljoin` which automatically does the right thing in all of the circumstances we care about. In fact, if `Location` is a full absolute URL, it will handle that properly too; that is,
```
urljoin(urlA, urlB) == urlB
```
If `urlB` is absolute. So it's safe for us to rely wholly on that behavior.

TESTING:
- Install the VSCode bundle
- Launch a session
- Open the session in a new tab so you can see the URL
- Grab the session URL but _without_ the `?location` portion. Keep the trailing slash
- Run the command:
```
API_DEBUG=1 ae5 call <SESSION_URL>
```
You should see something like this. Note that it is handling auth as well.
```
$ ae5 call https://6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com/
Connecting to user account anaconda-enterprise@anaconda.example.com.
GET https://6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com/ 302
-> GET https://anaconda.example.com/auth/realms/AnacondaPlatform/protocol/openid-connect/auth?state=e3108f79a536026fd7d60c867f6a55f2&client_id=session_client_6b85daf85a4f4f1d8040d2f9bde57540&nonce=5f130ebf180fbead064b1d22e9b2253e&scope=openid%20email%20profile&response_type=code&redirect_uri=https%3A%2F%2F6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com%2Fredirect_uri 302
-> GET https://6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com/redirect_uri?state=e3108f79a536026fd7d60c867f6a55f2&session_state=30b9335a-b968-47b7-9b30-890c75307326&iss=https%3A%2F%2Fanaconda.example.com%2Fauth%2Frealms%2FAnacondaPlatform&code=78991042-c38b-4fa8-a56b-088d77722138.30b9335a-b968-47b7-9b30-890c75307326.37dce7b0-b82b-4a48-86e4-84807c5ea037 302
GET https://6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com/ 302
GET https://6b85daf85a4f4f1d8040d2f9bde57540.anaconda.example.com/?folder=/opt/continuum/project 200
```