### PR TITLE
NOREF: add category support to sample lists

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -93,7 +93,7 @@ COLUMNS = {
     ],
     "resource_profile": ["name", "description", "cpu", "memory", "gpu", "id"],
     "editor": ["name", "id", "is_default", "packages"],
-    "sample": ["name", "id", "is_template", "is_default", "description", "download_url", "owner", "created", "updated"],
+    "sample": ["name", "id", "is_template", "is_default", "description", "download_url", "owner", "created", "updated", "categories"],
     "deployment": [
         "endpoint",
         "name",
@@ -499,7 +499,7 @@ class AESessionBase(object):
     def _format_table(self, response, columns):
         is_series = isinstance(response, dict)
         rlist = [response] if is_series else response
-        csrc = list(rlist[0]) if rlist else getattr(response, "_columns", ())
+        csrc = set.union(*map(set, rlist)) if rlist else getattr(response, "_columns", ())
         columns = [c.lstrip("?") for c in (columns or ())]
         cdst = [c for c in columns if c in csrc]
         cdst.extend(c for c in csrc if c not in columns and not c.startswith("_"))


### PR DESCRIPTION
I was seeing failures in anaconda-platform-system-test caused by a discrepancy between `sample info` and `sample list`. It turns out it was caused by the fact that the first sample project is missing a `columns` entry so it is omitted from the formatted record list. To fix we need to build the column list from the union of all record columns, not just the first one

```
                                                                 --- is_ ---
            name                            id                template  default                                                                 description                                                                                                       download_url                                            owner           categories
-----------------------------  -----------------------------  --------  -------  ------------------------------------------------------------------------------------------------------------------------------------------  ---------------------------------------------------------------------------------------  -------------  --------------------
Python 3.10                    template_python_310            True      True     Minimal Python 3.10 project.                                                                                                                http://anaconda-enterprise-ap-docs/docs/_static/gallery/template_python_310.tar.bz2      documentation
Python 3.11                    template_python_311            True      False    Minimal Python 3.11 project.                                                                                                                http://anaconda-enterprise-ap-docs/docs/_static/gallery/template_python_311.tar.bz2      documentation
Python 3.12                    template_python_312            True      False    Minimal Python 3.12 project.                                                                                                                http://anaconda-enterprise-ap-docs/docs/_static/gallery/template_python_312.tar.bz2      documentation
Python-Essentials              template_sampleproj            True      False    Packages most commonly used for Python data analysis and visualization.                                                                     http://anaconda-enterprise-ap-docs/docs/_static/gallery/template_sampleproj.tar.bz2      documentation
R-Essentials                   template_sampleprojr           True      False    Packages most commonly used for R development.                                                                                              http://anaconda-enterprise-ap-docs/docs/_static/gallery/template_sampleprojr.tar.bz2     documentation
Databases                      Databases                      False     False    Database access utilizing SQLAlchemy, Pandas, and Dask. [Tutorial]                                                                          https://anaconda.example.com/docs/_static/gallery/Databases.tar.bz2                      documentation  ['Python']
R Cars                         R-Cars                         False     False    An R example utilizes the "mtcars" dataset                                                                                                  https://anaconda.example.com/docs/_static/gallery/R-Cars.tar.bz2                         documentation  ['R']
HvPlot Notebook                HvPlot-Notebook                False     False    A simple notebook with an interactive HvPlot plot.                                                                                          https://anaconda.example.com/docs/_static/gallery/HvPlot-Notebook.tar.bz2                documentation  ['Python']
Portfolio Optimizer            Portfolio-Optimizer            False     False    Example finance-calculation dashboard using Panel and HoloViews                                                                             https://anaconda.example.com/docs/_static/gallery/Portfolio-Optimizer.tar.bz2            documentation  ['Python', 'Panel']
R Predictive Notebook          R-Predictive-Notebook          False     False    A simple R notebook.                                                                                                                        https://anaconda.example.com/docs/_static/gallery/R-Predictive-Notebook.tar.bz2          documentation  ['R']
Hadoop-Spark                   Hadoop-Spark                   False     False    A comprehensive project template that contains commonly used data science packages for Python 3.6 and R plus spark extensions and kernels.  https://anaconda.example.com/docs/_static/gallery/Hadoop-Spark.tar.bz2                   documentation  ['Python']
HoloViz                        HoloViz                        False     False    Visualizations with HoloViz.org tools. [Tutorial]                                                                                           https://anaconda.example.com/docs/_static/gallery/HoloViz.tar.bz2                        documentation  ['Python']
S3 Connection Example          S3-Connection-Example          False     False    A project template that uses Python to connect to
an AWS S3 bucket to read data from files stored
in a specific path.
                      https://anaconda.example.com/docs/_static/gallery/S3-Connection-Example.tar.bz2          documentation  ['Python']
Intro Data Analysis Workbook   Intro-Data-Analysis-Workbook   False     False    An example data analysis introduction                                                                                                       https://anaconda.example.com/docs/_static/gallery/Intro-Data-Analysis-Workbook.tar.bz2   documentation  ['Python']
R Uber Data Analysis           R-Uber-Data-Analysis           False     False    Uber data analysis using R                                                                                                                  https://anaconda.example.com/docs/_static/gallery/R-Uber-Data-Analysis.tar.bz2           documentation  ['R']
Markowitz Notebook             Markowitz-Notebook             False     False    Markowitz portfolio design using Pandas and Bokeh (requires access to the full Anaconda repository and the internet).                       https://anaconda.example.com/docs/_static/gallery/Markowitz-Notebook.tar.bz2             documentation  ['Python']
NYC Taxi                       NYC-Taxi                       False     False    A notebook showing datashaded taxi data. Requires access to the internet.                                                                   https://anaconda.example.com/docs/_static/gallery/NYC-Taxi.tar.bz2                       documentation  ['Python']
Plot Notebook                  Plot-Notebook                  False     False    A simple notebook with a Matplotlib plot.                                                                                                   https://anaconda.example.com/docs/_static/gallery/Plot-Notebook.tar.bz2                  documentation  ['Python']
Panel Gapminders               Panel-Gapminders               False     False    Using four different plotting libraries for the Hans Rosling gapminder example.                                                             https://anaconda.example.com/docs/_static/gallery/Panel-Gapminders.tar.bz2               documentation  ['Python', 'Panel']
Image Classifier (Flask)       Image-Classifier--Flask-       False     False    An example TensorFlow app with Flask.
Requires access to the full Anaconda repository and the internet.
                                    https://anaconda.example.com/docs/_static/gallery/Image-Classifier--Flask-.tar.bz2       documentation  ['Python']
Streaming OHLC Data            Streaming-OHLC-Data            False     False    An example Bokeh application that displays streaming data.                                                                                  https://anaconda.example.com/docs/_static/gallery/Streaming-OHLC-Data.tar.bz2            documentation  ['Python']
Data Cataloging                Data-Cataloging                False     False    Use Intake to distribute and ingest data [Tutorial]                                                                                         https://anaconda.example.com/docs/_static/gallery/Data-Cataloging.tar.bz2                documentation  ['Python']
R Customer Segmentation        R-Customer-Segmentation        False     False    Customer segmentation using R                                                                                                               https://anaconda.example.com/docs/_static/gallery/R-Customer-Segmentation.tar.bz2        documentation  ['R']
R Movie Recommendation System  R-Movie-Recommendation-System  False     False    Movie recommendation system using R                                                                                                         https://anaconda.example.com/docs/_static/gallery/R-Movie-Recommendation-System.tar.bz2  documentation  ['R']
Tensorboard MNIST Demo         Tensorboard-MNIST-Demo         False     False    An example of Tensorboard applied to MNIST character recognition data.
Requires access to the full Anaconda repository and the internet.
   https://anaconda.example.com/docs/_static/gallery/Tensorboard-MNIST-Demo.tar.bz2         documentation  ['Python']
Square Limit                   Square-Limit                   False     False    Recreating the Square Limit woodcut by M.C. Escher using Holoviews Spline.                                                                  https://anaconda.example.com/docs/_static/gallery/Square-Limit.tar.bz2                   documentation  ['Python']
Hello Anaconda Enterprise      Hello-Anaconda-Enterprise      False     False    A simple "hello world" anaconda-project app with only python as a dependency.                                                               https://anaconda.example.com/docs/_static/gallery/Hello-Anaconda-Enterprise.tar.bz2      documentation  ['Python']
R Data Analysis                R-Data-Analysis                False     False    Exploratory data analysis using R                                                                                                           https://anaconda.example.com/docs/_static/gallery/R-Data-Analysis.tar.bz2                documentation  ['R']
R Shiny Demo                   R-Shiny-Demo                   False     False    An example R Shiny app                                                                                                                      https://anaconda.example.com/docs/_static/gallery/R-Shiny-Demo.tar.bz2                   documentation  ['R', 'Shiny']
installer-builder-template     installer-builder-template     False     False    A project specifically for making installer-making-projects                                                                                 https://anaconda.example.com/docs/_static/gallery/installer-builder-template.tar.bz2     documentation  ['Python', 'System']
Glaciers                       Glaciers                       False     False    Glaciers explorer using Datashader and Panel                                                                                                https://anaconda.example.com/docs/_static/gallery/Glaciers.tar.bz2                       documentation  ['Python', 'Panel']
Image Classifier (Tornado)     Image-Classifier--Tornado-     False     False    An example TensorFlow app with Tornado.
Requires access to the full Anaconda repository and the internet.
                                  https://anaconda.example.com/docs/_static/gallery/Image-Classifier--Tornado-.tar.bz2     documentation  ['Python']
Gapminder Visualization        Gapminder-Visualization        False     False    An example Bokeh application.                                                                                                               https://anaconda.example.com/docs/_static/gallery/Gapminder-Visualization.tar.bz2        documentation  ['Python']
Attractors                     Attractors                     False     False    A panel dashboard using datashader to interact with attractor equations.                                                                    https://anaconda.example.com/docs/_static/gallery/Attractors.tar.bz2                     documentation  ['Python', 'Panel']
R Iris                         R-Iris                         False     False    Learning R on iris                                                                                                                          https://anaconda.example.com/docs/_static/gallery/R-Iris.tar.bz2                         documentation  ['R']
NYC buildings                  NYC-buildings                  False     False    NYC buildings                                                                                                                               https://anaconda.example.com/docs/_static/gallery/NYC-buildings.tar.bz2                  documentation  ['Python']
```